### PR TITLE
Warn about usage of `enabledManagers`

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,19 @@ We recommend moving it to `.github/renovate.json` if it is not already there.
       ]
     }
     ```
-3. That's it. Renovate will now use the custom configuration preset.
+
+3. By extending from `github>jenkinsci/renovate-config` any usage of `enabledManagers` will disable the default managers.
+   Unless there is a specific reason to do so, `enabledManagers` should be removed.
+
+    ```json5
+    # remove this
+    "enabledManagers": [
+      "customManager1",
+      "customManager2"
+    ]
+    ```
+  
+4. That's it. Renovate will now use the custom configuration preset.
 
 ## Development
 


### PR DESCRIPTION
Noticed this in https://github.com/jenkinsci/kubernetes-plugin/pull/2794 

I will try to set something up to discover usage of `enabledManagers` in other repos that may not be aware of this issue.

### Testing done

-

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
