### PR TITLE
Allow unlimited updates of plugin BOM major version

### DIFF
--- a/default.json
+++ b/default.json
@@ -8,6 +8,13 @@
     ":configMigration",
     "security:minimumReleaseAgeNpm"
   ],
+  "packageRules": [
+    {
+      "description": "Allow very large updates of plugin BOM",
+      "matchPackageNames": ["io.jenkins.tools.bom:bom-*"],
+      "maxMajorIncrement": 30000
+    }
+  ],
   "postUpdateOptions": ["yarnDedupeHighest"],
   "dependencyDashboardHeader": "This issue lists Renovate updates and detected dependencies. Read the [Dependency Dashboard](https://docs.renovatebot.com/key-concepts/dashboard/) docs to learn more.<br>The parent configuration is located in [jenkinsci/renovate-config](https://github.com/jenkinsci/renovate-config); Renovate logs for debug [here](https://developer.mend.io/{{platform}}/{{repository}}).",
   "labels": ["dependencies"],

--- a/default.json
+++ b/default.json
@@ -12,7 +12,7 @@
     {
       "description": "Allow very large updates of plugin BOM",
       "matchPackageNames": ["io.jenkins.tools.bom:bom-*"],
-      "maxMajorIncrement": 30000
+      "maxMajorIncrement": 0
     }
   ],
   "postUpdateOptions": ["yarnDedupeHighest"],


### PR DESCRIPTION
## Allow unlimited updates of plugin BOM major version

Fixes #21

Plugin BOM major version numbers increase rapidly.  Each release of a plugin in the plugin BOM increases the potential major version of the plugin BOM by 1.  We have 25 or more new plugin releases every week and some weeks we have many more than that.  Renovate does not propose new pull requests (by default) when the major number of a component has increased by more than 500.

That means new releases of the plugin BOM are not being evaluated in plugins that are using Renovate and have an older plugin BOM version.  The platformlabeler plugin is the example where I first detected it, but the issue occurs in many of the plugins that I maintain.  I'm trying to honor the suggestion from James Nord and Jesse Glick to not increment the plugin BOM, but I want to know that the latest plugin BOM works in my plugins.

Change copied from platformlabeler where it has been used for two weeks.

From platformlabeler pull request:

* https://github.com/jenkinsci/platformlabeler-plugin/pull/2034

### Testing done

* npm install
* npm test

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
