### PR TITLE
feat: pin GitHub Action digests

### DIFF
--- a/default.json
+++ b/default.json
@@ -5,6 +5,7 @@
     ":semanticCommitsDisabled",
     ":configMigration",
     "security:minimumReleaseAgeNpm",
+    "helpers:pinGitHubActionDigests",
     ":gitSignOff"
   ],
   "schedule": [


### PR DESCRIPTION
Adds the [`helpers:pinGitHubActionDigests`](https://docs.renovatebot.com/presets-helpers/#helperspingithubactiondigests) preset to the shared config.

## Why

Tags like `actions/checkout@v4` are mutable — whoever controls the tag controls what runs in our workflows. Pinning to a full commit SHA makes each action immutable, which is also what [OpenSSF Scorecard's Pinned-Dependencies check](https://github.com/ossf/scorecard/blob/main/docs/checks.md#pinned-dependencies) and the [GitHub hardening guide](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions) recommend.

Renovate keeps the version comment next to the SHA and continues to raise update PRs, so readability and upkeep stay the same:

```yaml
- uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
```

## Notes

- Existing repos will get one PR pinning their current actions, then business as usual.
- `npm test` (`renovate-config-validator --strict`) passes.